### PR TITLE
Add the Application Pool Identity account type for IIS7+ application poo...

### DIFF
--- a/IIS/CreateIisAppPoolActionEditor.cs
+++ b/IIS/CreateIisAppPoolActionEditor.cs
@@ -28,7 +28,7 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
             var action = (CreateIisAppPoolAction)extension;
 
             this.txtName.Text = action.Name;
-            if (new[] { "LocalSystem", "LocalService", "NetworkService" }.Contains(action.User, StringComparer.OrdinalIgnoreCase))
+            if (new[] { "LocalSystem", "LocalService", "NetworkService", "ApplicationPoolIdentity" }.Contains(action.User, StringComparer.OrdinalIgnoreCase))
             {
                 this.ddlUser.SelectedValue = action.User;
             }
@@ -72,6 +72,7 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
                     new ListItem("Local System", "LocalSystem"),
                     new ListItem("Local Service", "LocalService"),
                     new ListItem("Network Service", "NetworkService"),
+                    new ListItem("Application Pool Identity", "ApplicationPoolIdentity"),
                     new ListItem("Custom...", "custom")
                 }
             };

--- a/IIS/IIS7Util.cs
+++ b/IIS/IIS7Util.cs
@@ -107,6 +107,10 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
                             appPool.ProcessModel.IdentityType = ProcessModelIdentityType.NetworkService;
                             break;
 
+                        case "ApplicationPoolIdentity":
+                            appPool.ProcessModel.IdentityType = ProcessModelIdentityType.ApplicationPoolIdentity;
+                            break;
+
                         default:
                             appPool.ProcessModel.IdentityType = ProcessModelIdentityType.SpecificUser;
                             appPool.ProcessModel.UserName = user;


### PR DESCRIPTION
Since the recommended [identity type](http://www.iis.net/learn/manage/configuring-security/application-pool-identities) to use for IIS7 + is AppPoolIdentity i think this should be an available option when creation new application pools using the Windows extention.
This change allows this.

Note, although the included Microsoft.Web.Administration.dll lib is version 6.1 it still supports this identity type. Regardless i would recommend upgrading to the latest [version](https://www.nuget.org/packages/Microsoft.Web.Administration) And change the reference to use nuget instead of including the library with the source. (since the BM SDK is also using nuget it makes sense).
