### PR TITLE
Check if app pool and/or web site exist in IIS and omit action if true

### DIFF
--- a/IIS/CreateIisAppPoolAction.cs
+++ b/IIS/CreateIisAppPoolAction.cs
@@ -76,17 +76,21 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
 
         protected override string ProcessRemoteCommand(string name, string[] args)
         {
+           
             LogDebug("User: " + User);
             LogDebug("Pipeline: {0} ({1})", ManagedRuntimeVersion, IntegratedMode ? "integrated" : "classic");
+            LogDebug("Omit action if pool exists: {0}", OmitActionIfPoolExists);
             if (OmitActionIfPoolExists)
             {
-                if (!IISUtil.Instance.AppPoolExists(name))
+                LogDebug("Checking for pool with name: {0}", Name);
+                if (IISUtil.Instance.AppPoolExists(Name))
                 {
                     LogDebug(
                         "IIS Application Pool with name: {0} already exists. The Application Pool creation is omitted",
-                        name);
+                        Name);
                     return null;
                 }
+                LogDebug("IIS did not contain an App pool named {0}. Action is not omitted", Name);
             }
             IISUtil.Instance.CreateAppPool(Name, User, Password, IntegratedMode, ManagedRuntimeVersion);
 

--- a/IIS/CreateIisAppPoolActionEditor.cs
+++ b/IIS/CreateIisAppPoolActionEditor.cs
@@ -21,51 +21,54 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
         private PasswordTextBox txtPassword;
         private Div divUser;
         private RadioButtonList rblIntegrated;
+        private RadioButtonList rdbOmitActionIfPoolExists;
         private DropDownList ddlManagedRuntimeVersion;
 
         public override void BindToForm(ActionBase extension)
         {
-            var action = (CreateIisAppPoolAction)extension;
+            var action = (CreateIisAppPoolAction) extension;
 
-            this.txtName.Text = action.Name;
-            if (new[] { "LocalSystem", "LocalService", "NetworkService", "ApplicationPoolIdentity" }.Contains(action.User, StringComparer.OrdinalIgnoreCase))
+            txtName.Text = action.Name;
+            if (new[] {"LocalSystem", "LocalService", "NetworkService", "ApplicationPoolIdentity"}.Contains(
+                action.User, StringComparer.OrdinalIgnoreCase))
             {
-                this.ddlUser.SelectedValue = action.User;
+                ddlUser.SelectedValue = action.User;
             }
             else
             {
-                this.ddlUser.SelectedValue = "custom";
-                this.txtUser.Text = action.User;
-                this.txtPassword.Text = action.Password;
+                ddlUser.SelectedValue = "custom";
+                txtUser.Text = action.User;
+                txtPassword.Text = action.Password;
             }
 
-            this.rblIntegrated.SelectedValue = action.IntegratedMode.ToString().ToLower();
-            this.ddlManagedRuntimeVersion.SelectedValue = action.ManagedRuntimeVersion;
+            rblIntegrated.SelectedValue = action.IntegratedMode.ToString().ToLower();
+            ddlManagedRuntimeVersion.SelectedValue = action.ManagedRuntimeVersion;
+            rdbOmitActionIfPoolExists.SelectedValue = action.OmitActionIfPoolExists.ToString().ToLower();
         }
 
         public override ActionBase CreateFromForm()
         {
             return new CreateIisAppPoolAction()
             {
-                Name = this.txtName.Text,
-                User = this.ddlUser.SelectedValue == "custom" ? this.txtUser.Text : this.ddlUser.SelectedValue,
-                Password = this.ddlUser.SelectedValue == "custom" ? this.txtPassword.Text : "",
-                IntegratedMode = bool.Parse(this.rblIntegrated.SelectedValue),
-                ManagedRuntimeVersion = this.ddlManagedRuntimeVersion.SelectedValue
+                Name = txtName.Text,
+                User = ddlUser.SelectedValue == "custom" ? txtUser.Text : ddlUser.SelectedValue,
+                Password = ddlUser.SelectedValue == "custom" ? txtPassword.Text : "",
+                IntegratedMode = bool.Parse(rblIntegrated.SelectedValue),
+                ManagedRuntimeVersion = ddlManagedRuntimeVersion.SelectedValue
             };
         }
 
         protected override void OnPreRender(EventArgs e)
         {
-            this.Controls.Add(GetClientSideScript(this.ddlUser.ClientID, this.divUser.ClientID));
+            Controls.Add(GetClientSideScript(ddlUser.ClientID, divUser.ClientID));
 
             base.OnPreRender(e);
         }
 
         protected override void CreateChildControls()
         {
-            this.txtName = new ValidatingTextBox { Required = true };
-            this.ddlUser = new DropDownList
+            txtName = new ValidatingTextBox {Required = true};
+            ddlUser = new DropDownList
             {
                 Items =
                 {
@@ -77,29 +80,29 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
                 }
             };
 
-            this.txtUser = new ValidatingTextBox();
-            this.txtPassword = new PasswordTextBox();
+            txtUser = new ValidatingTextBox();
+            txtPassword = new PasswordTextBox();
 
-            this.divUser = new Div
-            { 
-                Controls = 
-                { 
-                    new LiteralControl("<br />"),
-                    new StandardFormField("User Name:", this.txtUser), 
-                    new StandardFormField("Password:", this.txtPassword)
-                } 
-            };
-
-            this.rblIntegrated = new RadioButtonList
+            divUser = new Div
             {
-                Items = 
-                { 
-                    new ListItem("Integrated Mode", "true"),
-                    new ListItem("Classic Mode", "false") 
+                Controls =
+                {
+                    new LiteralControl("<br />"),
+                    new StandardFormField("User Name:", txtUser),
+                    new StandardFormField("Password:", txtPassword)
                 }
             };
 
-            this.ddlManagedRuntimeVersion = new DropDownList
+            rblIntegrated = new RadioButtonList
+            {
+                Items =
+                {
+                    new ListItem("Integrated Mode", "true"),
+                    new ListItem("Classic Mode", "false")
+                }
+            };
+
+            ddlManagedRuntimeVersion = new DropDownList
             {
                 Items =
                 {
@@ -108,25 +111,33 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
                 }
             };
 
-            this.Controls.Add(
+            Controls.Add(
                 new SlimFormField(
                     "Application pool name:",
-                    this.txtName
-                ),
+                    txtName
+                    ),
                 new SlimFormField(
                     "User identity:",
-                    this.ddlUser,
-                    this.divUser
-                ),
+                    ddlUser,
+                    divUser
+                    ),
                 new SlimFormField(
                     "Managed pipeline mode:",
-                    this.rblIntegrated
-                ),
+                    rblIntegrated
+                    ),
                 new SlimFormField(
                     "Managed runtime version:",
-                    this.ddlManagedRuntimeVersion
-                )
-            );
+                    ddlManagedRuntimeVersion
+                    )
+                );
+
+            rdbOmitActionIfPoolExists = new RadioButtonList
+            {
+                Items =
+                {
+                    new ListItem("Omit action if pool already exists", "true"),
+                }
+            };
         }
 
         private RenderJQueryDocReadyDelegator GetClientSideScript(string ddlUserId, string divUserId)
@@ -136,22 +147,21 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
                     "var onload = $('#" + ddlUserId + "').find('option').filter(':selected').val();" +
                     "if(onload == 'custom')" +
                     "{" +
-                        "$('#" + divUserId + "').show();" +
+                    "$('#" + divUserId + "').show();" +
                     "}" +
-
                     "$('#" + ddlUserId + "').change(function () {" +
-                        "var selectedConfig = $(this).find('option').filter(':selected').val();" +
-                        "if(selectedConfig == 'custom')" +
-                        "{" +
-                            "$('#" + divUserId + "').show();" +
-                        "}" +
-                        "else" +
-                        "{" +
-                            "$('#" + divUserId + "').hide();" +
-                        "}" +
+                    "var selectedConfig = $(this).find('option').filter(':selected').val();" +
+                    "if(selectedConfig == 'custom')" +
+                    "{" +
+                    "$('#" + divUserId + "').show();" +
+                    "}" +
+                    "else" +
+                    "{" +
+                    "$('#" + divUserId + "').hide();" +
+                    "}" +
                     "}).change();"
-                )
-            );
+                    )
+                );
         }
     }
 }

--- a/IIS/CreateIisAppPoolActionEditor.cs
+++ b/IIS/CreateIisAppPoolActionEditor.cs
@@ -21,8 +21,9 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
         private PasswordTextBox txtPassword;
         private Div divUser;
         private RadioButtonList rblIntegrated;
-        private RadioButtonList rdbOmitActionIfPoolExists;
+        private RadioButtonList rdlOmitActionIfPoolExists;
         private DropDownList ddlManagedRuntimeVersion;
+        private CheckBoxList chkBoxlistOmitAction;
 
         public override void BindToForm(ActionBase extension)
         {
@@ -43,18 +44,20 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
 
             rblIntegrated.SelectedValue = action.IntegratedMode.ToString().ToLower();
             ddlManagedRuntimeVersion.SelectedValue = action.ManagedRuntimeVersion;
-            rdbOmitActionIfPoolExists.SelectedValue = action.OmitActionIfPoolExists.ToString().ToLower();
+            chkBoxlistOmitAction.SelectedValue = action.OmitActionIfPoolExists.ToString().ToLower();
         }
 
         public override ActionBase CreateFromForm()
         {
+            var omitIfAppPoolExist = chkBoxlistOmitAction.Items.FindByText("if App Pool already exist.")?.Selected ?? false;
             return new CreateIisAppPoolAction()
             {
                 Name = txtName.Text,
                 User = ddlUser.SelectedValue == "custom" ? txtUser.Text : ddlUser.SelectedValue,
                 Password = ddlUser.SelectedValue == "custom" ? txtPassword.Text : "",
                 IntegratedMode = bool.Parse(rblIntegrated.SelectedValue),
-                ManagedRuntimeVersion = ddlManagedRuntimeVersion.SelectedValue
+                ManagedRuntimeVersion = ddlManagedRuntimeVersion.SelectedValue,
+                OmitActionIfPoolExists = omitIfAppPoolExist
             };
         }
 
@@ -111,6 +114,15 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
                 }
             };
 
+            chkBoxlistOmitAction = new CheckBoxList
+            {
+                Items =
+                {
+                    new ListItem("if App Pool already exist.","true"),
+                }
+            };
+
+
             Controls.Add(
                 new SlimFormField(
                     "Application pool name:",
@@ -128,16 +140,12 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
                 new SlimFormField(
                     "Managed runtime version:",
                     ddlManagedRuntimeVersion
+                    ),
+                new SlimFormField(
+                    "Omit action:",
+                    chkBoxlistOmitAction
                     )
                 );
-
-            rdbOmitActionIfPoolExists = new RadioButtonList
-            {
-                Items =
-                {
-                    new ListItem("Omit action if pool already exists", "true"),
-                }
-            };
         }
 
         private RenderJQueryDocReadyDelegator GetClientSideScript(string ddlUserId, string divUserId)

--- a/IIS/CreateIisWebSiteAction.cs
+++ b/IIS/CreateIisWebSiteAction.cs
@@ -49,6 +49,13 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
         [Persistent]
         public string IPAddress { get; set; }
 
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the action should be ignored if the Web Site aready exists.
+        /// </summary>
+        [Persistent]
+        public bool OmitActionIfWebSiteExists { get; set; }
+
         public override ActionDescription GetActionDescription()
         {
             return new ActionDescription(
@@ -72,6 +79,20 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
         {
             this.LogDebug("Physical Path: {0}", this.PhysicalPath);
             this.LogDebug("App Pool: {0}", this.ApplicationPool);
+            LogDebug("Omit action if Web site exists: {0}", OmitActionIfWebSiteExists);
+
+            if (OmitActionIfWebSiteExists)
+            {
+                LogDebug("Checking for Web site with name: {0}", Name);
+                if (IISUtil.Instance.WebSiteExists(Name))
+                {
+                    LogDebug(
+                        "IIS Web site with name: {0} already exists. The Web site creation is omitted",
+                        Name);
+                    return Domains.YN.Yes;
+                }
+                LogDebug("IIS did not contain a Web site named {0}. Action is not omitted", Name);
+            }
 
             int port = string.IsNullOrEmpty(this.Port) ? 80 : InedoLib.Util.Int.ParseZ(this.Port);
             if (port < 1 || port > ushort.MaxValue)

--- a/IIS/CreateIisWebSiteActionEditor.cs
+++ b/IIS/CreateIisWebSiteActionEditor.cs
@@ -1,4 +1,5 @@
-﻿using Inedo.BuildMaster.Extensibility.Actions;
+﻿using System.Web.UI.WebControls;
+using Inedo.BuildMaster.Extensibility.Actions;
 using Inedo.BuildMaster.Web.Controls.Extensions;
 using Inedo.Web.Controls;
 
@@ -12,6 +13,7 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
         private ValidatingTextBox txtPort;
         private ValidatingTextBox txtHostName;
         private ValidatingTextBox txtIPAddress;
+        private CheckBoxList chkBoxlistOmitAction;
 
         public override void BindToForm(ActionBase extension)
         {
@@ -23,10 +25,13 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
             this.txtPort.Text = action.Port;
             this.txtHostName.Text = action.HostName;
             this.txtIPAddress.Text = action.IPAddress;
+            chkBoxlistOmitAction.SelectedValue = action.OmitActionIfWebSiteExists.ToString().ToLower();
         }
 
         public override ActionBase CreateFromForm()
         {
+            var omitIfWebsiteExist = chkBoxlistOmitAction.Items.FindByText("if web site already exist.")?.Selected ?? false;
+
             return new CreateIisWebSiteAction()
             {
                 Name = this.txtName.Text,
@@ -34,7 +39,8 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
                 ApplicationPool = this.txtApplicationPoolName.Text,
                 Port = this.txtPort.Text,
                 HostName = this.txtHostName.Text,
-                IPAddress = this.txtIPAddress.Text
+                IPAddress = this.txtIPAddress.Text,
+                OmitActionIfWebSiteExists = omitIfWebsiteExist,
             };
         }
 
@@ -46,6 +52,13 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
             this.txtPort = new ValidatingTextBox { DefaultText = "80" };
             this.txtHostName = new ValidatingTextBox { DefaultText = "any" };
             this.txtIPAddress = new ValidatingTextBox { DefaultText = "All unassigned" };
+            chkBoxlistOmitAction = new CheckBoxList
+            {
+                Items =
+                {
+                    new ListItem("if web site already exist.","true"),
+                }
+            };
 
             this.Controls.Add(
                 new SlimFormField(
@@ -71,7 +84,11 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
                 new SlimFormField(
                     "IP address:",
                     this.txtIPAddress
-                )
+                ),
+                new SlimFormField(
+                    "Omit action:",
+                    chkBoxlistOmitAction
+                    )
             );
         }
     }

--- a/IIS/IIS6Util.cs
+++ b/IIS/IIS6Util.cs
@@ -62,7 +62,27 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
                 throw new NotSupportedException();
             }
 
+            /// <summary>
+            /// Check if an IIS Application Pool of name <paramref name="appPoolName"/> exists.
+            /// </summary>
+            /// <param name="appPoolName">The name of the IIS Application Pool to look for</param>
+            /// <returns>True if the AppPool already exists else false</returns>
+            public override bool AppPoolExists(string appPoolName)
+            {
+                throw new NotSupportedException();
+            }
+
             public override void CreateWebSite(string name, string path, string appPool, bool https, BindingInfo binding)
+            {
+                throw new NotSupportedException();
+            }
+
+            /// <summary>
+            /// Check if an IIS hosted website of name <paramref name="name"/> exists.
+            /// </summary>
+            /// <param name="name">The name of the website to look for in the IIS</param>
+            /// <returns>True if website already exists else false</returns>
+            public override bool WebSiteExists(string name)
             {
                 throw new NotSupportedException();
             }

--- a/IIS/IIS7Util.cs
+++ b/IIS/IIS7Util.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Inedo.Diagnostics;
 using Microsoft.Web.Administration;
@@ -33,6 +34,7 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
                         yield return pool.Name;
                 }
             }
+
             /// <summary>
             /// Starts an AppPool on the local system.
             /// </summary>
@@ -55,6 +57,7 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
                     }
                 }
             }
+
             /// <summary>
             /// Stops an AppPool on the local system.
             /// </summary>
@@ -73,7 +76,7 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
                     }
                     catch (COMException ex)
                     {
-                        if ((uint)ex.ErrorCode == 0x80070426)
+                        if ((uint) ex.ErrorCode == 0x80070426)
                             throw new IISException("Application pool is already stopped.", ex, MessageLevel.Information);
                         else
                             throw new IISException("Could not stop application pool: " + ex.Message);
@@ -85,12 +88,15 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
                 }
             }
 
-            public override void CreateAppPool(string name, string user, string password, bool integratedMode, string managedRuntimeVersion)
+            public override void CreateAppPool(string name, string user, string password, bool integratedMode,
+                string managedRuntimeVersion)
             {
                 using (var manager = new ServerManager())
                 {
                     var appPool = manager.ApplicationPools.Add(name);
-                    appPool.ManagedPipelineMode = integratedMode ? ManagedPipelineMode.Integrated : ManagedPipelineMode.Classic;
+                    appPool.ManagedPipelineMode = integratedMode
+                        ? ManagedPipelineMode.Integrated
+                        : ManagedPipelineMode.Classic;
                     appPool.ManagedRuntimeVersion = managedRuntimeVersion;
 
                     switch (user)
@@ -123,6 +129,20 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
                 }
             }
 
+            /// <summary>
+            /// Check if an IIS Application Pool of name <paramref name="appPoolName"/> exists.
+            /// </summary>
+            /// <param name="appPoolName">The name of the IIS Application Pool to look for</param>
+            /// <returns>True if the AppPool already exists else false</returns>
+            public override bool AppPoolExists(string appPoolName)
+            {
+                using (var manager = new ServerManager())
+                {
+                    var pool = manager.ApplicationPools[appPoolName];
+                    return pool != null;
+                }
+            }
+
             public override void CreateWebSite(string name, string path, string appPool, bool https, BindingInfo binding)
             {
                 using (var manager = new ServerManager())
@@ -130,6 +150,20 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
                     var site = manager.Sites.Add(name, https ? "https" : "http", binding.ToString(), path);
                     site.ApplicationDefaults.ApplicationPoolName = appPool;
                     manager.CommitChanges();
+                }
+            }
+
+            /// <summary>
+            /// Check if an IIS hosted website of name <paramref name="name"/> exists.
+            /// </summary>
+            /// <param name="name">The name of the website to look for in the IIS</param>
+            /// <returns>True if website already exists else false</returns>
+            public override bool WebSiteExists(string name)
+            {
+                using (var manager = new ServerManager())
+                {
+                    var site = manager.Sites.SingleOrDefault(s => s.Name.Equals(name));
+                    return site != null;
                 }
             }
 

--- a/IIS/IIS7Util.cs
+++ b/IIS/IIS7Util.cs
@@ -136,11 +136,7 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
             /// <returns>True if the AppPool already exists else false</returns>
             public override bool AppPoolExists(string appPoolName)
             {
-                using (var manager = new ServerManager())
-                {
-                    var pool = manager.ApplicationPools[appPoolName];
-                    return pool != null;
-                }
+                return GetAppPoolNames().Any(poolName => poolName.Equals(appPoolName));
             }
 
             public override void CreateWebSite(string name, string path, string appPool, bool https, BindingInfo binding)
@@ -162,8 +158,7 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
             {
                 using (var manager = new ServerManager())
                 {
-                    var site = manager.Sites.SingleOrDefault(s => s.Name.Equals(name));
-                    return site != null;
+                    return manager.Sites.Any(site => site.Name.Equals(name));
                 }
             }
 

--- a/IIS/IISUtil.cs
+++ b/IIS/IISUtil.cs
@@ -72,6 +72,15 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
         /// <param name="integratedMode">If true, sets the app pool mode to integrated.</param>
         /// <param name="managedRuntimeVersion">The version of .NET hosting the app pool.</param>
         public abstract void CreateAppPool(string name, string user, string password, bool integratedMode, string managedRuntimeVersion);
+
+        /// <summary>
+        /// Check if an IIS Application Pool of name <paramref name="appPoolName"/> exists.
+        /// </summary>
+        /// <param name="appPoolName">The name of the IIS Application Pool to look for</param>
+        /// <returns>True if the AppPool already exists else false</returns>
+        public abstract bool AppPoolExists(string appPoolName);
+
+
         /// <summary>
         /// Creates a new website.
         /// </summary>
@@ -81,6 +90,15 @@ namespace Inedo.BuildMasterExtensions.Windows.Iis
         /// <param name="https">Binds to HTTPS instead of HTTP</param>
         /// <param name="binding">The port, hostname, and IP of the website.</param>
         public abstract void CreateWebSite(string name, string path, string appPool, bool https, BindingInfo binding);
+
+        /// <summary>
+        /// Check if an IIS hosted website of name <paramref name="name"/> exists.
+        /// </summary>
+        /// <param name="name">The name of the website to look for in the IIS</param>
+        /// <returns>True if website already exists else false</returns>
+        public abstract bool WebSiteExists(string name);
+
+
 
         /// <summary>
         /// Returns a new instances of the newest supported IIS management interface.


### PR DESCRIPTION
This is a response to the http://inedo.com/support/questions/3988 where Alana points out that i could modify the codebase to allow for prevalidation of action execution.

I have added functionality for checking if the IIS already has a pool or website with the same name.
Optionally you can choose to then omit the action and go on without breaking the entire deployment.

Default behavior is to always omit if the IIS contains the same pool of website. 
